### PR TITLE
orderページの実装

### DIFF
--- a/app/controllers/ApplicationController.php
+++ b/app/controllers/ApplicationController.php
@@ -6,4 +6,13 @@ class ApplicationController {
   protected function connect_db() {
     return connect_db();
   }
+  protected function is_logged_in() {
+    if(!isset($_SESSION)){
+      session_start();
+    }
+    if(!isset($_SESSION['id'])) {
+      header('Location: http://192.168.64.2/kit-web-application/');
+      exit;
+    }
+  }
 }

--- a/app/controllers/CartsController.php
+++ b/app/controllers/CartsController.php
@@ -6,9 +6,7 @@ class CartsController extends ApplicationController {
   public function index() {
     $products = array();
 
-    if(!isset($_SESSION)){
-      session_start();
-    }
+    Parent::is_logged_in();
 
     if (isset($_SESSION['id'])) {
       $products = OrderHistory::find_cart_products_by_user_id($_SESSION['id']);
@@ -20,15 +18,13 @@ class CartsController extends ApplicationController {
     echo view($title, $body, $data);
   }
   public function create() {
-      if(!isset($_SESSION)){
-        session_start();
-      }
+      
+      Parent::is_logged_in();
       if(isset($_SESSION['id'])) {
         OrderHistory::add_carts($_POST['product_id']);
         header('Location: http://192.168.64.2/kit-web-application/carts');
         exit;
       }
-      //仮
       header('Location: http://192.168.64.2/kit-web-application/');
       exit;
   }

--- a/app/controllers/OrdersController.php
+++ b/app/controllers/OrdersController.php
@@ -1,23 +1,63 @@
 <?
 require_once __DIR__ . "/./ApplicationController.php";
 require_once __DIR__ . "/../models/OrderHistory.php";
+require_once __DIR__ . "/../models/User.php";
 
 class OrdersController extends ApplicationController {
   public function index() {
-  }
-  public function new() {
+      $products = array();
+
+      Parent::is_logged_in();
       
+      if (isset($_SESSION['id'])) {
+        $products = OrderHistory::find_parchased_products_by_user_id($_SESSION['id']);
+      }
+
+      $title = "注文履歴";
+      $body = __DIR__ . '/../views/orders/index.php';
+      $data = array('products' => $products);
+      echo view($title, $body, $data);
   }
+    
+  public function new() {
+      $products = array();
+      $user = array();
+      Parent::is_logged_in();
+
+      if (isset($_SESSION['id'])) {
+        $products = OrderHistory::find_cart_products_by_user_id($_SESSION['id']);
+        $user = User::find_by_id($_SESSION['id']);
+      }
+      $data = array('products' => $products,'user' => $user[0], 'total_price' => self::price_calculation($products));
+      $title = "注文内容確認";
+      $body = __DIR__ . '/../views/orders/new.php';
+      echo view($title, $body,$data);
+  }
+    
   public function create() {
+      
+      Parent::is_logged_in();
+      
+      if (isset($_SESSION['id'])) {
+        OrderHistory::give_order();
+      }
+      header('Location: http://192.168.64.2/kit-web-application/orders');
+      exit;
   }
   public function edit() {
-    if(!isset($_SESSION)){
-      session_start();
-    }
+    
+    Parent::is_logged_in();
     $quantity = $_POST['quantity'];
     $product_id = $_POST['product_id'];
     OrderHistory::edit_product_quantity($quantity,$product_id);
     header('Location: http://192.168.64.2/kit-web-application/carts');
     exit;
+  }
+  public function price_calculation($products){
+      $total_price = 0;
+      foreach ($products as $product) {
+          $total_price += $product['price'] * $product['quantity'];
+      }
+      return $total_price;
   }
 }

--- a/app/controllers/ProductsController.php
+++ b/app/controllers/ProductsController.php
@@ -8,7 +8,6 @@ class ProductsController {
       $keys = parse_url($_SERVER["REQUEST_URI"]); //パース処理
       $path = explode("/", $keys['path']); //分割処理
       $last = end($path); //最後の要素を取得
-      if($last == 1) {
       $product = Product::find_by_id($last);
       $data = array('id'          => $product[0]['id'],
                     'name'        => $product[0]['name'],
@@ -16,7 +15,6 @@ class ProductsController {
                     'price'       => $product[0]['price'],
                     'category'    => $product[0]['category'],
                     'image_url'   => $product[0]['image_url']);
-      }
       echo view($title, $body, $data);
   }
 }

--- a/app/models/Product.php
+++ b/app/models/Product.php
@@ -40,8 +40,8 @@ class Product extends ApplicationModel {
       return $result;
     } catch (PDOException $e) {
       die('Error:' . $e->getMessage());
+   }
   }
-}
 
   public function save() {
     $db = parent::connect_db();

--- a/app/models/User.php
+++ b/app/models/User.php
@@ -17,7 +17,20 @@ class User extends ApplicationModel {
     $this->zip_code = $params['zip_code'];
     $this->address = $params['address'];
   }
-
+  public function find_by_id($id){
+    try {
+      $db = parent::connect_db();
+      $sth = $db->prepare('
+        SELECT * FROM users WHERE id = :id;'
+      );
+      $sth->bindValue(':id', $id, PDO::PARAM_INT);
+      $sth->execute();
+      $result = $sth->fetchAll(PDO::FETCH_ASSOC);
+      return $result;
+    } catch (PDOException $e) {
+      die('Error:' . $e->getMessage());
+    }
+  }
   public function save() {
     try {
       $db = parent::connect_db();

--- a/app/views/carts/index.php
+++ b/app/views/carts/index.php
@@ -2,7 +2,9 @@
   <div style="display: flex; flex-direction:row; justify-content: space-between;">
     <h2>カート</h2>
     <? if (count($products) != 0) { ?>
-    <button type="button" class="btn btn-primary" style="width: 200px; margin-bottom: 32px;">注文</button>
+    <form method="GET" action="/kit-web-application/orders/new">
+      <button type="submit" class="btn btn-primary" style="width: 200px; margin-bottom: 32px;">注文</button>
+    </form>
     <? } ?>
   </div>
   <div>
@@ -16,7 +18,8 @@
         alt="">
         <div style="width: 50%;">
           <h3><? echo $product['name'] ?></h3>
-          <div><? echo $product['price'] ?></div>
+          <div>単価:<? echo $product['price'] ?>円</div>
+          <div>合計価格:<? echo $product['price'] * $product['quantity'] ?>円</div>
           <label for="">個数:<? echo $product['quantity'] ?></label>
           <form method="POST" action="/kit-web-application/orders/edit">
             <input type="hidden" name="product_id" value=<?= $product['product_id'] ?> >

--- a/app/views/layouts/header.php
+++ b/app/views/layouts/header.php
@@ -34,12 +34,14 @@ if (!isset($_SESSION)) {
         </a>
       </li>
     <? } ?>
-    <li class="nav-item">
-      <a class="nav-link" href="/kit-web-application/carts" style="color: #fff;">
-        カート
-        <i class="fas fa-shopping-cart"></i>
-      </a>
-    </li>
+    <? if (isset($_SESSION['name'])) { ?>
+      <li class="nav-item">
+        <a class="nav-link" href="/kit-web-application/carts" style="color: #fff;">
+          カート
+          <i class="fas fa-shopping-cart"></i>
+        </a>
+      </li>
+    <? } ?>
   </ul>
 </nav>
 

--- a/app/views/orders/index.php
+++ b/app/views/orders/index.php
@@ -1,22 +1,28 @@
-<div class="wrapper">
-    <div class="list-group" id="junre-box">
-        <div class="list-group-item" style="background-color: #f5f5f5">ジャンル一覧</div>
-        <a href="#" class="list-group-item">スポーツ</a>
-        <a href="#" class="list-group-item">食べ物</a>
-        <a href="#" class="list-group-item">漫画</a>
-        <a href="#" class="list-group-item">旅行</a>
-    </div>
-    <img src="" class="product-img">
-    <div class="card">
-        <div class="card-body">
-            <h4 class="card-title"><?= $name ?></h4>
-            <p class="card-text">【価格】<?= $price ?>円</p>
-            <p class="card-text">【商品説明】<br><?= $description ?></p>
-            <form method="post" action="http://192.168.64.2/kit-web-application/carts">
-                <input type="hidden" value=<?= $id ?> name="product_id">
-                <button type="submit" class="btn btn-primary">購入する</button>
-            </form>
+<div class="container" style="margin-top: 32px;">
+  <div style="display: flex; flex-direction:row; justify-content: space-between;">
+    <h2>注文履歴</h2>
+  </div>
+  <div>
+    <? foreach ($products as $product) { ?>
+      <div style="border: 1px solid #ddd; width: 100%; padding: 24px; display: flex; justify-content: space-between;">
+      <img
+        src="<? echo $product['image_url'] ?>"
+        width="200px"
+        height="200px"
+        style="margin-right: auto;"
+        alt="">
+        <div style="width: 50%; margin: auto;">
+          <h3><? echo $product['name'] ?></h3>
+          <div>単価:<? echo $product['price'] ?>円</div>
+          <div>合計価格:<? echo $product['quantity'] * $product['price'] ?>円</div>
+          <div>個数:<? echo $product['quantity'] ?></div>
+          <div>購入日:<? echo $product['created_at'] ?></div>
         </div>
     </div>
+    <? } ?>
+  </div>
+  <? if (count($products) == 0) { ?>
+    <p>まだ購入したことがありません。</p>
+  <? } ?>
 </div>
 

--- a/app/views/orders/new.php
+++ b/app/views/orders/new.php
@@ -1,23 +1,40 @@
-<div class="wrapper">
-    <div class="list-group" id="junre-box">
-        <div class="list-group-item" style="background-color: #f5f5f5">ジャンル一覧</div>
-        <a href="#" class="list-group-item">スポーツ</a>
-        <a href="#" class="list-group-item">食べ物</a>
-        <a href="#" class="list-group-item">漫画</a>
-        <a href="#" class="list-group-item">旅行</a>
+<div class="container" style="margin-top: 32px;">
+  <h1 style="border-bottom: 1px solid #e1e4e8;">お届け内容の確認</h2>
+  <? if (count($products) == 0) { ?>
+    <p>注文するものがありません。</p>
+  <? } else { ?>
+　<div style="display: flex; flex-direction:row; justify-content: space-between;">
+    <div>
+      <h2>お届け先</h2>
+　    <p>〒<? echo $user['zip_code']?> 住所: <? echo $user['address']?></p>
+      <h2>注文内容</h2>
+      <? foreach ($products as $product) { ?>
+        <div style="border: 1px solid #ddd; width: 100%; padding: 12px; display: flex; justify-content: space-between;">
+        <img
+          src="<? echo $product['image_url'] ?>"
+          width="200px"
+          height="200px"
+          style="margin-right: auto;"
+          alt="">
+          <div style="width: 60%;">
+            <h4><? echo $product['name'] ?></h4>
+            <div>単価:<? echo $product['price'] ?>円</div>
+            <div>合計金額:<? echo $product['price'] * $product['quantity'] ?>円</div>
+            <label for="">個数:<? echo $product['quantity'] ?></label>
+          </div>
+      </div>
+      <? } ?>
     </div>
-    <img src="" class="product-img">
     <div class="card">
-        <div class="card-body">
-            <h4 class="card-title"><?= $name ?></h4>
-            <p class="card-text">【価格】<?= $price ?>円</p>
-            <p class="card-text">【商品説明】<br><?= $description ?></p>
-            <form method="post" action="http://192.168.64.2/kit-web-application/carts">
-                <input type="hidden" value=<?= $id ?> name="product_id">
-                <button type="submit" class="btn btn-primary">購入する</button>
-            </form>
-        </div>
+      <div class="card-body">
+        <p class="card-text">小計:   <? echo $total_price?>円</p>
+        <p class="card-text">送料:   0円</p>
+        <p class="card-text">合計:   <? echo $total_price?>円</p>
+        <form method="POST" action="/kit-web-application/orders">
+          <button type="submit" class="btn btn-primary">注文を確定する</button>
+        </form>
+      </div>
     </div>
+  </div>
+　<? } ?>
 </div>
-
-


### PR DESCRIPTION
## やったこと
- orders/newページの追加(カートから注文ボタンを押した時に出る確認画面)
- orders/newページから注文を確定するボタンを押すとカートの商品が全て注文履歴に入るように変更
- orders/indexページの追加(注文履歴一覧を表示する画面)
- ログインしていない時にheaderのカートを表示しないように変更
- cartsControllerとordersControllerの各メソッドの最初にログインしているかチェック。していなかったらルートページに遷移するように変更
## 画像
### ログインしていない時のheaderの画像
<img width="1423" alt="スクリーンショット 2020-01-08 2 59 06" src="https://user-images.githubusercontent.com/28621439/71917227-f01bed80-31c2-11ea-9cde-63b4bdcae6a3.png">

### 注文履歴画面(orders/index.php)
<img width="715" alt="スクリーンショット 2020-01-08 2 58 55" src="https://user-images.githubusercontent.com/28621439/71917228-f01bed80-31c2-11ea-9ba0-361f345b4d7b.png">

### 注文確認画面(orders/new.php)
<img width="1378" alt="スクリーンショット 2020-01-08 2 58 42" src="https://user-images.githubusercontent.com/28621439/71917229-f01bed80-31c2-11ea-946a-f9c97b7939ae.png">



